### PR TITLE
changed `hmac.compare_digest()` to `==`

### DIFF
--- a/modules/PageServer.py
+++ b/modules/PageServer.py
@@ -71,7 +71,7 @@ class mainlogin:
 			return "User does not exist!"
 
 		# hash submited password and compare to record
-		if hmac.compare_digest(record['Password'].encode("utf-8"),hmac.new('QVkey123',var['Password'],hashlib.sha512).hexdigest()):
+		if record['Password'].encode("utf-8") == hmac.new('QVkey123',var['Password'],hashlib.sha512).hexdigest():
 
 			# create login session, redirect if success
 			if logman.Login(var['Username']):

--- a/modules/logins.py
+++ b/modules/logins.py
@@ -59,7 +59,7 @@ class loginmanager:
 
 			# test if session information matches
 			if rec != None:
-				if hmac.compare_digest(rec['QV_Ses'].encode("utf-8"),ses):
+				if rec['QV_Ses'].encode("utf-8") == ses:
 					print "Logged In"
 					return True
 		return False
@@ -77,7 +77,7 @@ class loginmanager:
 
 			# test if session information matches
 			if rec != None:
-				if hmac.compare_digest(rec['QV_Ses'].encode("utf-8"),ses):
+				if rec['QV_Ses'].encode("utf-8") == ses:
 					# Remove session from mongodb
 					qv_sessions.delete_one({'Username' : usr})
 


### PR DESCRIPTION
the system's python (2.7.6) does not support `compare_digest`

I'm well-aware that this is not ideal... but the server has version 2.7.6 installed and as stated in [the 2.7 docs](https://docs.python.org/2.7/library/hmac.html#hmac.compare_digest), `compare_digest` has only been introduced in 2.7.7 :-(

So, this reverts back to the insecure `==` for now
